### PR TITLE
adjust address templates for checkout, order and address book

### DIFF
--- a/JapaneseAddress/etc/config.xml
+++ b/JapaneseAddress/etc/config.xml
@@ -20,21 +20,21 @@
                 <country_show>0</country_show>
             </address>
             <address_templates>
-                <text><![CDATA[{{depend postcode}}〒{{var postcode}}{{/depend}}
+                <text><![CDATA[{{depend prefix}}{{var prefix}} {{/depend}}{{var lastname}} {{depend middlename}}{{var middlename}} {{/depend}}{{var firstname}}{{depend suffix}} {{var suffix}}{{/depend}}{{depend lastnamekana}} ({{var lastnamekana}} {{var firstnamekana}}){{/depend}}
+{{depend postcode}}〒{{var postcode}}{{/depend}}
 {{depend region}}{{var region}}{{/depend}}{{depend city}}{{var city}}{{/depend}}{{depend street1}}{{var street1}} {{/depend}}{{depend street2}}{{var street2}}{{/depend}}{{depend street3}}{{var street3}}{{/depend}}
-{{depend prefix}}{{var prefix}} {{/depend}}{{var lastname}} {{depend middlename}}{{var middlename}} {{/depend}}{{var firstname}}{{depend suffix}} {{var suffix}}{{/depend}}{{depend lastnamekana}} ({{var lastnamekana}} {{var firstnamekana}}){{/depend}}
 {{depend telephone}}T: {{var telephone}}{{/depend}}
 {{depend fax}}F: {{var fax}}{{/depend}}
 ]]></text>
-                <oneline><![CDATA[{{depend postcode}}〒{{var postcode}} {{/depend}}{{depend region}}{{var region}}{{/depend}}{{var city}}{{depend city}}{{/depend}}{{depend street1}}{{var street1}} {{/depend}}{{depend street2}}{{var street2}}{{/depend}}{{depend street3}}{{var street3}}{{/depend}} {{depend prefix}}{{var prefix}} {{/depend}}{{var lastname}} {{depend middlename}}{{var middlename}} {{/depend}}{{var firstname}}{{depend suffix}} {{var suffix}}{{/depend}}{{depend lastnamekana}} ({{var lastnamekana}} {{var firstnamekana}}){{/depend}}]]></oneline>
-                <html><![CDATA[{{depend postcode}}〒{{var postcode}}{{/depend}}<br />
+                <oneline><![CDATA[{{depend prefix}}{{var prefix}} {{/depend}}{{var lastname}} {{depend middlename}}{{var middlename}} {{/depend}}{{var firstname}}{{depend suffix}} {{var suffix}}{{/depend}}{{depend lastnamekana}} ({{var lastnamekana}} {{var firstnamekana}}){{/depend}} {{depend postcode}}〒{{var postcode}} {{/depend}}{{depend region}}{{var region}}{{/depend}}{{var city}}{{depend city}}{{/depend}}{{depend street1}}{{var street1}} {{/depend}}{{depend street2}}{{var street2}}{{/depend}}{{depend street3}}{{var street3}}{{/depend}}]]></oneline>
+                <html><![CDATA[{{depend prefix}}{{var prefix}} {{/depend}}{{var lastname}} {{depend middlename}}{{var middlename}} {{/depend}}{{var firstname}}{{depend suffix}} {{var suffix}}{{/depend}}{{depend lastnamekana}} ({{var lastnamekana}} {{var firstnamekana}}){{/depend}}<br/>
+{{depend postcode}}〒{{var postcode}}{{/depend}}<br />
 {{depend region}}{{var region}}{{/depend}}{{depend city}}{{var city}}{{/depend}}{{depend street1}}{{var street1}} {{/depend}}{{depend street2}}{{var street2}}{{/depend}}{{depend street3}}{{var street3}}{{/depend}}<br />
-{{depend prefix}}{{var prefix}} {{/depend}}{{var lastname}} {{depend middlename}}{{var middlename}} {{/depend}}{{var firstname}}{{depend suffix}} {{var suffix}}{{/depend}}{{depend lastnamekana}} ({{var lastnamekana}} {{var firstnamekana}}){{/depend}}
 {{depend telephone}}<br />T: {{var telephone}}{{/depend}}
 {{depend fax}}<br />F: {{var fax}}{{/depend}}<br />]]></html>
-                <pdf><![CDATA[{{depend postcode}}〒{{var postcode}}{{/depend}}|
+                <pdf><![CDATA[{{depend prefix}}{{var prefix}} {{/depend}}{{var lastname}} {{depend middlename}}{{var middlename}} {{/depend}}{{var firstname}}{{depend suffix}} {{var suffix}}{{/depend}}{{depend lastnamekana}} ({{var lastnamekana}} {{var firstnamekana}}){{/depend}}|
+{{depend postcode}}〒{{var postcode}}{{/depend}}|
 {{depend region}}{{var region}}{{/depend}}{{depend city}}{{var city}}{{/depend}}{{depend street1}}{{var street1}}{{/depend}}{{depend street2}}{{var street2}} {{/depend}}{{depend street3}}{{var street3}}{{/depend}}|
-{{depend prefix}}{{var prefix}} {{/depend}}{{var lastname}} {{depend middlename}}{{var middlename}} {{/depend}}{{var firstname}}{{depend suffix}} {{var suffix}}{{/depend}}{{depend lastnamekana}} ({{var lastnamekana}} {{var firstnamekana}}){{/depend}}
 {{depend telephone}}|T: {{var telephone}}{{/depend}}
 {{depend fax}}|F: {{var fax}}{{/depend}}|]]></pdf>
             </address_templates>

--- a/JapaneseAddress/view/frontend/web/template/checkout/billing-address/details.html
+++ b/JapaneseAddress/view/frontend/web/template/checkout/billing-address/details.html
@@ -5,12 +5,12 @@
  */
 -->
 <div if="isAddressDetailsVisible() && currentBillingAddress()" class="billing-address-details">
-    〒<text args="currentBillingAddress().postcode"/><br/>
-    <text args="currentBillingAddress().region"/><text args="currentBillingAddress().city"/><text args="_.values(currentBillingAddress().street)[0]"/>
-    <text args="_.values(currentBillingAddress().street)[1]"/><text args="_.values(currentBillingAddress().street)[2]"/></br>
     <text args="currentBillingAddress().prefix"/> <text args="currentBillingAddress().lastname"/> <text args="currentBillingAddress().middlename"/>
     <text args="currentBillingAddress().firstname"/> <text args="currentBillingAddress().suffix"/>
     <text if="currentBillingAddress().getNamekana()" args="'(' + currentBillingAddress().getNamekana() + ')'"/><br/>
+    〒<text args="currentBillingAddress().postcode"/><br/>
+    <text args="currentBillingAddress().region"/><text args="currentBillingAddress().city"/><text args="_.values(currentBillingAddress().street)[0]"/>
+    <text args="_.values(currentBillingAddress().street)[1]"/><text args="_.values(currentBillingAddress().street)[2]"/></br>
     <a if="currentBillingAddress().telephone" attr="'href': 'tel:' + currentBillingAddress().telephone" text="currentBillingAddress().telephone"></a><br/>
 
     <if args="_.isArray(currentBillingAddress().customAttributes)">

--- a/JapaneseAddress/view/frontend/web/template/checkout/shipping-address/address-renderer/jp.html
+++ b/JapaneseAddress/view/frontend/web/template/checkout/shipping-address/address-renderer/jp.html
@@ -6,12 +6,12 @@
 -->
 
 <div class="shipping-address-item" css="'selected-item' : isSelected() , 'not-selected-item':!isSelected()">
-    〒<text args="address().postcode"/><br/>
-    <text args="address().region"/><text args="address().city"/><text args="_.values(address().street)[0]"/>
-    <text args="_.values(address().street)[1]"/><text args="_.values(address().street)[2]"/></br>
     <text args="address().prefix"/> <text args="address().lastname"/> <text args="address().middlename"/>
     <text args="address().firstname"/> <text args="address().suffix"/>
     <text if="address().getNamekana()" args="'(' + address().getNamekana() + ')'"/><br/>
+    〒<text args="address().postcode"/><br/>
+    <text args="address().region"/><text args="address().city"/><text args="_.values(address().street)[0]"/>
+    <text args="_.values(address().street)[1]"/><text args="_.values(address().street)[2]"/></br>
     <a if="address().telephone" attr="'href': 'tel:' + address().telephone" text="address().telephone"></a><br/>
 
     <if args="_.isArray(address().customAttributes)">

--- a/JapaneseAddress/view/frontend/web/template/checkout/shipping-information/address-renderer/jp.html
+++ b/JapaneseAddress/view/frontend/web/template/checkout/shipping-information/address-renderer/jp.html
@@ -5,12 +5,12 @@
  */
 -->
 <if args="visible()">
-    〒<text args="address().postcode"/><br/>
-    <text args="address().region"/><text args="address().city"/><text args="_.values(address().street)[0]"/>
-    <text args="_.values(address().street)[1]"/><text args="_.values(address().street)[2]"/></br>
     <text args="address().prefix"/> <text args="address().lastname"/> <text args="address().middlename"/>
     <text args="address().firstname"/> <text args="address().suffix"/>
     <text if="address().getNamekana()" args="'(' + address().getNamekana() + ')'"/><br/>
+    〒<text args="address().postcode"/><br/>
+    <text args="address().region"/><text args="address().city"/><text args="_.values(address().street)[0]"/>
+    <text args="_.values(address().street)[1]"/><text args="_.values(address().street)[2]"/></br>
     <a if="address().telephone" attr="'href': 'tel:' + address().telephone" text="address().telephone"></a><br/>
 
     <if args="_.isArray(address().customAttributes)">


### PR DESCRIPTION
I think placing name data as the first position of address data. I checked already launched Japanese M2 based websites. All of them are using similar format.