### PR TITLE
Fixed when Currency Code is Null

### DIFF
--- a/CurrencyPrecision/Observer/AdjustCurrencyPrecision.php
+++ b/CurrencyPrecision/Observer/AdjustCurrencyPrecision.php
@@ -39,7 +39,7 @@ class AdjustCurrencyPrecision implements ObserverInterface
         $currencyCode = $event->getData('base_code');
         $currencyOptions = $event->getData('currency_options');
 
-        $currencyOptions->addData($this->getPrecisionOptions($currencyCode));
+        $currencyCode == null ? : $currencyOptions->addData($this->getPrecisionOptions($currencyCode));
 
         return $this;
     }

--- a/CurrencyPrecision/Plugin/Directory/Model/CurrencyPrecisionFormatting.php
+++ b/CurrencyPrecision/Plugin/Directory/Model/CurrencyPrecisionFormatting.php
@@ -47,8 +47,10 @@ class CurrencyPrecisionFormatting
         $options = []
     ) {
         //round before formatting to apply configured rounding mode.
-        $price = $this->currencyRounding->round($currency->getCode(), (float)$price);
-        $options['precision'] = $this->currencyRounding->getPrecision($currency->getCode());
+        if ($currency->getCode() != null) {
+            $price = $this->currencyRounding->round($currency->getCode(), (float)$price);
+            $options['precision'] = $this->currencyRounding->getPrecision($currency->getCode());
+        }
         return [$price, $options];
     }
 }


### PR DESCRIPTION
Fixed error on order view page:

"Information Changes have been made to this section that have not been saved. This tab contains invalid data. Please resolve this before saving."