### PR TITLE
Fixed customer export error on customer grid page.

### DIFF
--- a/JapaneseAddress/Plugin/Ui/View/Element/PartiallyConfiguredUiComponent.php
+++ b/JapaneseAddress/Plugin/Ui/View/Element/PartiallyConfiguredUiComponent.php
@@ -32,11 +32,11 @@ class PartiallyConfiguredUiComponent
     public function afterGetChildComponents(UiComponentInterface $component, array $children)
     {
         $configuredChildren = [];
-        foreach ($children as $child) {
+        foreach ($children as $key => $child) {
             if ($child instanceof Field && null === $child->getData('config/formElement')) {
                 continue;
             }
-            $configuredChildren[] = $child;
+            $configuredChildren[$key] = $child;
         }
         return $configuredChildren;
     }


### PR DESCRIPTION
I got the below error when I try to export customer data as CSV on a customer grid page.
>Notice: Undefined index: listing_top in /xxx/vendor/magento/module-ui/Model/Export/MetadataProvider.php on line 224

↓$childComponents has order numbers as array keys instead of string like 'listing_top' when I enable CommunityEngineering_JapaneseAddress module.

>Magento\Ui\Model\Export\MetadataProvider
>
>223 $childComponents = $component->getChildComponents();
>224 $listingTop = $childComponents['listing_top'];

The reason is that the below method changes array keys to order numbers.
>CommunityEngineering\JapaneseAddress\Plugin\Ui\View\Element\PartiallyConfiguredUiComponent::afterGetChildComponents