### PR TITLE
Fix issue with missing method argument type

### DIFF
--- a/JapaneseName/Model/DataObject/Copy.php
+++ b/JapaneseName/Model/DataObject/Copy.php
@@ -7,6 +7,7 @@ declare(strict_types=1);
 
 namespace CommunityEngineering\JapaneseName\Model\DataObject;
 
+use Magento\Framework\Api\ExtensibleDataInterface;
 /**
  * Behavior of this class should be moved to Magento\Framework\DataObject\Copy eventually.
  *
@@ -129,7 +130,7 @@ class Copy extends \Magento\Framework\DataObject\Copy
     /**
      * @inheritdoc
      */
-    protected function setAttributeValueFromExtensibleDataObject($target, $code, $value)
+    protected function setAttributeValueFromExtensibleDataObject(ExtensibleDataInterface $target, $code, $value)
     {
         try {
             parent::setAttributeValueFromExtensibleDataObject($target, $code, $value);

--- a/JapaneseYenFormatting/Model/CurrencyFormatOptionModifiers.php
+++ b/JapaneseYenFormatting/Model/CurrencyFormatOptionModifiers.php
@@ -34,7 +34,7 @@ class CurrencyFormatOptionModifiers
      * @param string $currencyCode
      * @return array
      */
-    public function getOptions(string $currencyCode): array
+    public function getOptions(string $currencyCode = ''): array
     {
         if ($currencyCode !== 'JPY') {
             return [];

--- a/JapaneseYenFormatting/Model/CurrencyFormatOptionModifiers.php
+++ b/JapaneseYenFormatting/Model/CurrencyFormatOptionModifiers.php
@@ -34,7 +34,7 @@ class CurrencyFormatOptionModifiers
      * @param string $currencyCode
      * @return array
      */
-    public function getOptions(string $currencyCode = ''): array
+    public function getOptions(string $currencyCode): array
     {
         if ($currencyCode !== 'JPY') {
             return [];

--- a/JapaneseYenFormatting/Observer/ModifyCurrencyFormattingOptions.php
+++ b/JapaneseYenFormatting/Observer/ModifyCurrencyFormattingOptions.php
@@ -42,8 +42,9 @@ class ModifyCurrencyFormattingOptions implements ObserverInterface
         $currencyCode = $event->getData('base_code');
         $currencyOptions = $event->getData('currency_options');
 
-        $currencyOptions->addData($this->currencyFormatOptionModifiers->getOptions($currencyCode));
-
+        if ($currencyCode !== null) {
+            $currencyOptions->addData($this->currencyFormatOptionModifiers->getOptions($currencyCode));
+        }
         return $this;
     }
 }


### PR DESCRIPTION
Fixed issue:
`"Warning: Declaration of CommunityEngineering\JapaneseName\Model\DataObject\Copy::setAttributeValueFromExtensibleDataObject($target, $code, $value) should be compatible with Magento\Framework\DataObject\Copy::setAttributeValueFromExtensibleDataObject(Magento\Framework\Api\ExtensibleDataInterface $target, $code, $value) in /var/www/html/vendor/community-engineering/module-japanese-name/Model/DataObject/Copy.php on line 19"`